### PR TITLE
Add optional length constraints.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ with Factory Girl like this.
 ```ruby
 Factory.define(:user) do |u|
   u.name { "#{RandomWord.adjs.next} User" }
-  u.email { "#{u.name.gsub(/ +/, '.')}@example.com" }
+  u.email { "#{name.gsub(/ +/, '.')}@example.com" }
 end
 
 Factory(:user) #=> ...

--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,15 @@ an object that responds to `#===` to the exclude list.
 This will prevent the return of the exact string `"bar"` and any word
 which matches the regex `/fo+/`.
 
+Constraining word length
+----
+
+You can constrain the length of words provided by the `nouns` and `adjs` iterators like so:
+```ruby
+RandomWord.nouns(not_longer_than: 56).next
+RandomWord.adjs(not_shorter_than: 3).next
+RandomWord.adjs(not_shorter_than: 16, not_longer_than: 672).next
+```
 
 Contributing to random-word
 ----

--- a/README.markdown
+++ b/README.markdown
@@ -14,20 +14,24 @@ Usage
 You can get a random word any where you need one. Just request the
 next of which ever word flavor you prefer.
 
-    RandomWord.adjs.next  #=> "pugnacious"
-    RandomWord.nouns.next #=> "audience"
+```ruby
+RandomWord.adjs.next  #=> "pugnacious"
+RandomWord.nouns.next #=> "audience"
+```
     
 ### Factory Girl
 
 This library was first developed to use in factories. It can be used
 with Factory Girl like this.
 
-    Factory.define(:user) do |u|
-      u.name  "#{RandomWord.adjs.next} User"
-      u.email {|u| "#{u.name.gsub(/ +/, '.')}@example.com"
-    end
+```ruby
+Factory.define(:user) do |u|
+  u.name  "#{RandomWord.adjs.next} User"
+  u.email {|u| "#{u.name.gsub(/ +/, '.')}@example.com"
+end
 
-    Factory(:user) #=> ...
+Factory(:user) #=> ...
+```
 
 Exclusion
 ----
@@ -35,8 +39,10 @@ Exclusion
 Words may be excluded by pattern, or exact match. To do this just add
 an object that responds to `#===` to the exclude list.
 
-    RandomWord.exclude_list << /fo+/
-    RandomWord.exclude_list << 'bar'
+```ruby
+RandomWord.exclude_list << /fo+/
+RandomWord.exclude_list << 'bar'
+```
 
 This will prevent the return of the exact string `"bar"` and any word
 which matches the regex `/fo+/`.
@@ -45,6 +51,7 @@ Constraining word length
 ----
 
 You can constrain the length of words provided by the `nouns` and `adjs` iterators like so:
+
 ```ruby
 RandomWord.nouns(not_longer_than: 56).next
 RandomWord.adjs(not_shorter_than: 3).next

--- a/lib/random_word.rb
+++ b/lib/random_word.rb
@@ -9,6 +9,8 @@ require 'pathname'
 module RandomWord
   module EachRandomly
     attr_accessor :random_word_exclude_list
+    attr_accessor :min_length
+    attr_accessor :max_length
 
     def each_randomly(&blk)
       used = Set.new
@@ -18,6 +20,10 @@ module RandomWord
         used << idx
         word = at(idx)
         next if exclude_list.any?{|r| r === word }
+        next if word.length < min_length
+        unless max_length.nil?
+          next if word.length > max_length
+        end
         yield word
       end
 
@@ -46,13 +52,13 @@ module RandomWord
     end
 
     # @return [Enumerator] Random noun enumerator
-    def nouns
-      @nouns ||= enumerator(load_word_list("nouns.dat"), exclude_list)
+    def nouns(opts = {})
+      @nouns ||= enumerator(load_word_list("nouns.dat"), exclude_list, opts)
     end
 
     # @return [Enumerator] Random adjective enumerator
-    def adjs
-      @adjs ||= enumerator(load_word_list("adjs.dat"), exclude_list)
+    def adjs(opts = {})
+      @adjs ||= enumerator(load_word_list("adjs.dat"), exclude_list, opts)
     end
 
     # @return [Enumerator] Random phrase enumerator
@@ -68,9 +74,11 @@ module RandomWord
 
     # Create a random, non-repeating enumerator for a list of words
     # (or anything really).
-    def enumerator(word_list, list_of_regexs_or_strings_to_exclude = [])
+    def enumerator(word_list, list_of_regexs_or_strings_to_exclude = [], opts = {})
       word_list.extend EachRandomly
       word_list.random_word_exclude_list = list_of_regexs_or_strings_to_exclude
+      word_list.min_length = opts[:not_shorter_than] || 1
+      word_list.max_length = opts[:not_longer_than] || nil
       word_list.enum_for(:each_randomly)
     end
 

--- a/spec/random_word_spec.rb
+++ b/spec/random_word_spec.rb
@@ -91,75 +91,99 @@ describe "RandomWord#nouns", "with exclusions" do
 end
 
 shared_examples 'allows constraints on word length' do |method|
-  let(:word_list) { %w(aa bbb cccc ddddd) }
+  context 'when constraining' do
+    let(:word_list) { %w(aa bbb cccc ddddd) }
 
-  before(:each) do
-    expect(RandomWord).to receive(:load_word_list).and_return(word_list)
-  end
+    before(:each) do
+      expect(RandomWord).to receive(:load_word_list).and_return(word_list)
+    end
 
-  after(:each) do
-    RandomWord.instance_eval{ @nouns, @adjs = nil, nil }
-  end
+    after(:each) do
+      RandomWord.instance_eval{ @nouns, @adjs = nil, nil }
+    end
 
-  let(:next_words) do
-    [].tap do |next_words|
-      loop do
-        begin
-          next_words << RandomWord.send(method, length_constraints).next
-        rescue StopIteration
-          # We've tried all the words in the short test list we're using.
-          break
+    let(:next_words) do
+      [].tap do |next_words|
+        loop do
+          begin
+            next_words << RandomWord.send(method, length_constraints).next
+          rescue StopIteration
+            # We've tried all the words in the short test list we're using.
+            break
+          end
         end
       end
     end
-  end
 
-  context 'when constraining by maximum length' do
-    let(:length_constraints) { {not_longer_than: 2} }
+    context 'by maximum length' do
+      let(:length_constraints) { {not_longer_than: 2} }
 
-    it 'excludes the correct words' do
-      expect(next_words).to match_array %w(aa)
-    end
-  end
-
-  context 'when constraining by minimum length' do
-    let(:length_constraints) { {not_shorter_than: 4} }
-
-    it 'excludes the correct words' do
-      expect(next_words).to match_array %w(cccc ddddd)
+      it 'excludes the correct words' do
+        expect(next_words).to match_array %w(aa)
+      end
     end
 
-  end
+    context 'by minimum length' do
+      let(:length_constraints) { {not_shorter_than: 4} }
 
-  context 'when constraining by both minimum and maximum length' do
-    let(:length_constraints) { {not_shorter_than: 3, not_longer_than: 4} }
+      it 'excludes the correct words' do
+        expect(next_words).to match_array %w(cccc ddddd)
+      end
 
-    it 'excludes the correct words' do
-      expect(next_words).to match_array %w(bbb cccc)
+    end
+
+    context 'by both minimum and maximum length' do
+      let(:length_constraints) { {not_shorter_than: 3, not_longer_than: 4} }
+
+      it 'excludes the correct words' do
+        expect(next_words).to match_array %w(bbb cccc)
+      end
+    end
+
+    context 'by a perverse minimum length' do
+      let(:length_constraints) { {not_shorter_than: -1234} }
+
+      it 'includes all words' do
+        expect(next_words).to match_array word_list
+      end
+    end
+
+    context 'by a perverse maximum length' do
+      let(:length_constraints) { {not_longer_than: -34234} }
+
+      it 'excludes all words' do
+        expect(next_words).to be_empty
+      end
+    end
+
+    context 'and all words are within the constraints' do
+      let(:length_constraints) { {not_shorter_than: 2, not_longer_than: 5} }
+
+      it 'includes all words' do
+        expect(next_words).to match_array word_list
+      end
     end
   end
+end
 
-  context 'when given a perverse minimum length' do
-    let(:length_constraints) { {not_shorter_than: -1234} }
+shared_examples 'changing constraints in subsequent calls' do |method|
+  context 'when changing constraints in subsequent calls' do
+    let(:word_list) { %w(defenestrate as can jubilant orangutan hat) }
 
-    it 'includes all words' do
-      expect(next_words).to match_array word_list
+    before(:each) do
+      expect(RandomWord).to receive(:load_word_list).and_return(word_list)
     end
-  end
 
-  context 'when given a perverse maximum length' do
-    let(:length_constraints) { {not_longer_than: -34234} }
-
-    it 'excludes all words' do
-      expect(next_words).to be_empty
+    after(:each) do
+      RandomWord.instance_eval{ @nouns, @adjs = nil, nil }
     end
-  end
 
-  context 'when all words are within the constraints' do
-    let(:length_constraints) { {not_shorter_than: 2, not_longer_than: 5} }
-
-    it 'includes all words' do
-      expect(next_words).to match_array word_list
+    it 'applies the new constraints' do
+      short_words = %w(as can hat)
+      long_words = %w(defenestrate jubilant orangutan)
+      3.times { expect(short_words).to include RandomWord.send(method, not_longer_than: 3).next }
+      3.times { expect(long_words).to include RandomWord.send(method, not_longer_than: 150).next }
+      expect { RandomWord.send(method).next }.to raise_exception StopIteration
     end
   end
 end
@@ -167,9 +191,11 @@ end
 describe RandomWord do
   context '#nouns' do
     include_examples 'allows constraints on word length', :nouns
+    include_examples 'changing constraints in subsequent calls', :nouns
   end
 
   context '#adjs' do
     include_examples 'allows constraints on word length', :adjs
+    include_examples 'changing constraints in subsequent calls', :adjs
   end
 end

--- a/spec/random_word_spec.rb
+++ b/spec/random_word_spec.rb
@@ -13,7 +13,7 @@ describe RandomWord, "enumerator" do
     expect{subject.next}.to raise_error(StopIteration)
   end
 
-  it "make sure each word is only returned once" do 
+  it "make sure each word is only returned once" do
     already_received = []
     3.times do
       expect(new_word = subject.next).not_to be_one_of(already_received)
@@ -90,3 +90,86 @@ describe "RandomWord#nouns", "with exclusions" do
 
 end
 
+shared_examples 'allows constraints on word length' do |method|
+  let(:word_list) { %w(aa bbb cccc ddddd) }
+
+  before(:each) do
+    expect(RandomWord).to receive(:load_word_list).and_return(word_list)
+  end
+
+  after(:each) do
+    RandomWord.instance_eval{ @nouns, @adjs = nil, nil }
+  end
+
+  let(:next_words) do
+    [].tap do |next_words|
+      loop do
+        begin
+          next_words << RandomWord.send(method, length_constraints).next
+        rescue StopIteration
+          # We've tried all the words in the short test list we're using.
+          break
+        end
+      end
+    end
+  end
+
+  context 'when constraining by maximum length' do
+    let(:length_constraints) { {not_longer_than: 2} }
+
+    it 'excludes the correct words' do
+      expect(next_words).to match_array %w(aa)
+    end
+  end
+
+  context 'when constraining by minimum length' do
+    let(:length_constraints) { {not_shorter_than: 4} }
+
+    it 'excludes the correct words' do
+      expect(next_words).to match_array %w(cccc ddddd)
+    end
+
+  end
+
+  context 'when constraining by both minimum and maximum length' do
+    let(:length_constraints) { {not_shorter_than: 3, not_longer_than: 4} }
+
+    it 'excludes the correct words' do
+      expect(next_words).to match_array %w(bbb cccc)
+    end
+  end
+
+  context 'when given a perverse minimum length' do
+    let(:length_constraints) { {not_shorter_than: -1234} }
+
+    it 'includes all words' do
+      expect(next_words).to match_array word_list
+    end
+  end
+
+  context 'when given a perverse maximum length' do
+    let(:length_constraints) { {not_longer_than: -34234} }
+
+    it 'excludes all words' do
+      expect(next_words).to be_empty
+    end
+  end
+
+  context 'when all words are within the constraints' do
+    let(:length_constraints) { {not_shorter_than: 2, not_longer_than: 5} }
+
+    it 'includes all words' do
+      expect(next_words).to match_array word_list
+    end
+  end
+end
+
+describe RandomWord do
+  context '#nouns' do
+    include_examples 'allows constraints on word length', :nouns
+  end
+
+  context '#adjs' do
+    include_examples 'allows constraints on word length', :adjs
+  end
+end


### PR DESCRIPTION
`RandomWord` is often used to obtain names for factory-built objects. Name attributes commonly have constraints on their length enforced by `ActiveRecord` validations or similar mechanisms.

Some of `RandomWord`'s "words" are actually snake-case phrases, and can be surprisingly long. The longest noun is "american_federation_of_labor_and_congress_of_industrial_organizations", with 69 characters. The longest adjective is "naked_as_the_day_you_were_born", with 30 characters.

Thus the odds that `RandomWord` will provide a word that causes a maximum length validation failure are greater than one might have assumed. I ran into this problem with an attribute constrained to 75 characters. That seems quite long, but the factory prefixed the random word with 19 additional characters, and `RandomWord` has 7 words longer than 56 characters.

I expanded the `.nouns` and `.adjs` APIs to allow constraining the length of the words returned. Examples:
```ruby
RandomWord.nouns(not_longer_than: 56).next
RandomWord.adjs(not_shorter_than: 3).next
RandomWord.adjs(not_shorter_than: 16, not_longer_than: 672).next
```

You may quibble with the negative sense of the constraints. My reasoning: attribute length validations are expressed in terms of the minimum and/or maximum permitted length. For example:
```ruby
validates_length_of :first_name, :maximum => 30
```
I prefer saying
```ruby
RandomWord.nouns(not_longer_than: 30).next
```
to
```ruby
RandomWord.nouns(shorter_than_or_equal_to: 30).next
```
or
```ruby
RandomWord.nouns(shorter_than: 31).next
```