### PR TITLE
Add rng accessor so a specific seed/rng can be used

### DIFF
--- a/lib/random_word.rb
+++ b/lib/random_word.rb
@@ -38,18 +38,26 @@ module RandomWord
       @max_length = opts[:not_longer_than] || Float::INFINITY
     end
 
+    def rng=(r)
+      @_rng = r
+    end
+    def rng
+      @_rng ||= Random.new(Random.new_seed)
+    end
+
     def self.extended(mod)
       mod.set_constraints
     end
 
     private
 
+    
     def next_unused_idx(used)
-      idx = rand(length)
+      idx = rng.rand(length)
       try = 1
       while used.include?(idx)
         raise OutOfWords if try > 1000
-        idx = rand(length)
+        idx = rng.rand(length)
         try += 1
       end
 
@@ -69,6 +77,10 @@ module RandomWord
 
     def exclude_list
       @exclude_list ||= []
+    end
+
+    def rng=(r)
+      word_list.rng = r
     end
 
     # @return [Enumerator] Random noun enumerator

--- a/spec/random_word_spec.rb
+++ b/spec/random_word_spec.rb
@@ -188,14 +188,40 @@ shared_examples 'changing constraints in subsequent calls' do |method|
   end
 end
 
+shared_examples 'with a seed specified' do |method|
+  context 'when setting seed' do
+    let(:word_list) { %w(defenestrate as can jubilant orangutan hat) }
+
+    before(:each) do
+      expect(RandomWord).to receive(:load_word_list).and_return(word_list)
+    end
+
+    after(:each) do
+      RandomWord.instance_eval{ @nouns, @adjs = nil, nil }
+    end
+
+    it 'applies the new constraints' do
+      RandomWord.rng = Random.new 1234
+
+      short_words = %w(as can hat)
+      long_words = %w(defenestrate jubilant orangutan)
+      3.times { expect(short_words).to include RandomWord.send(method, not_longer_than: 3).next }
+      3.times { expect(long_words).to include RandomWord.send(method, not_longer_than: 150).next }
+      expect { RandomWord.send(method).next }.to raise_exception StopIteration
+    end
+  end
+end
+
 describe RandomWord do
   context '#nouns' do
     include_examples 'allows constraints on word length', :nouns
     include_examples 'changing constraints in subsequent calls', :nouns
+    include_examples 'with a seed specified', :nouns
   end
 
   context '#adjs' do
     include_examples 'allows constraints on word length', :adjs
     include_examples 'changing constraints in subsequent calls', :adjs
+    include_examples 'with a seed specified', :adjs
   end
 end


### PR DESCRIPTION
Hello! This PR adds a couple of methods to allow a user to specify a `Random` object as the random number generator, which makes the gem usable if you need some sort of deterministic randomness (which I do!)