### PR TITLE
Use #to_enum to fix Enum.new deprecation warnings

### DIFF
--- a/HISTORY.markdown
+++ b/HISTORY.markdown
@@ -1,3 +1,7 @@
+2.1.1
+----
+ * Fix deprecation warning
+
 1.3
 ----
  * Added exclude patterns. This makes it easy to prevent words with certain patterns from being returned.

--- a/lib/random_word.rb
+++ b/lib/random_word.rb
@@ -87,13 +87,13 @@ module RandomWord
 
     # @return [Enumerator] Random phrase enumerator
     def phrases
-      @phrases ||= Enumerator.new(Class.new do 
+      @phrases ||= (Class.new do
         def each()
           while true
             yield "#{RandomWord.adjs.next} #{RandomWord.nouns.next}"
           end
         end
-      end.new)
+      end.new).to_enum
     end
 
     # Create a random, non-repeating enumerator for a list of words

--- a/lib/random_word/version.rb
+++ b/lib/random_word/version.rb
@@ -1,3 +1,3 @@
 module RandomWord
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
Currently this gem always emits this warning:

```
random-word-2.1.0/lib/random_word.rb:90: warning: Enumerator.new without a block is deprecated; use Object#to_enum
```

This is due to Enumerator.new without a block being deprecated in Ruby 2.0.

This commit fixes this deprecation warning by calling `#to_enum` on the
random phrase enumerator object.