### PR TITLE
Remove null from the list of adjectives

### DIFF
--- a/data/adjs.json
+++ b/data/adjs.json
@@ -1,5 +1,4 @@
 [
-  null,
   "a",
   "a_cappella",
   "a_couple_of",


### PR DESCRIPTION
Hi There!

We encountered an issue when using this gem due to the presence of the `null` obj in the adjective list. This is causing the raising of an exception when checking for the word length in the `excluded?` method.

Best,
Luca