### PR TITLE
Remove null from adjs list

### DIFF
--- a/data/adjs.json
+++ b/data/adjs.json
@@ -1,5 +1,4 @@
 [
-  null,
   "a",
   "a_cappella",
   "a_couple_of",


### PR DESCRIPTION
There is a `null` in the `adjs` JSON file. If `RandomWord.adjs.next` is called enough times, it will eventually raise a `NoMethodError` due to this:

```
irb(main):003:0> 10000.times { RandomWord.adjs.next }
Traceback (most recent call last):
        5: from irb:in `each'
        4: from /Users/ggrossman/Code/ggrossman/random-word/lib/random_word.rb:19:in `each_randomly'
        3: from /Users/ggrossman/Code/ggrossman/random-word/lib/random_word.rb:19:in `loop'
        2: from /Users/ggrossman/Code/ggrossman/random-word/lib/random_word.rb:23:in `block in each_randomly'
        1: from /Users/ggrossman/Code/ggrossman/random-word/lib/random_word.rb:61:in `excluded?'
NoMethodError (undefined method `length' for nil:NilClass)
irb(main):004:0> 
```

With the `null` removed, `StopIteration` is raised instead as expected:

```
irb(main):005:0> 10000.times { RandomWord.adjs.next }
Traceback (most recent call last):
       16: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
       15: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
       14: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
       13: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
       12: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
       11: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
       10: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
        9: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
        8: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
        7: from /Users/ggrossman/.rbenv/versions/2.7.5/bin/irb:23:in `<top (required)>'
        6: from /Users/ggrossman/.rbenv/versions/2.7.5/bin/irb:23:in `load'
        5: from /Users/ggrossman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        4: from (irb):5
        3: from (irb):5:in `times'
        2: from (irb):5:in `block in irb_binding'
        1: from (irb):5:in `next'
StopIteration (iteration reached an end)
irb(main):006:0> 
```